### PR TITLE
[WIP]ロータリーエンコーダ―の修正版．しかしまだ修正必要

### DIFF
--- a/WBRControl.ino
+++ b/WBRControl.ino
@@ -1,5 +1,7 @@
 #include <WBRControl.h>
 
+
+
 // ピン番号アサイン(0はセンサーを使用しないことを指定）
 #define LEFT_MOTOR_PWM_GO       11    // 左モーターのＰＷＭ正接出力ピン(デジタル)
 #define LEFT_MOTOR_PWM_BACK     10    // 左モーターのＰＷＭ逆接出力ピン(デジタル)
@@ -12,6 +14,8 @@
 #define SIDE_RIGHT_SENSOR       2     // 右側面センサのピン番号（デジタル）
 #define SIDE_LEFT_SENSOR        7     // 左側面センサのピン番号（デジタル）
 #define MAGNET_SENSOR           12    // 給電所で磁力を検知するためのセンサのピン番号(そもそもセンサが存在するのだろうか？)(センサ番号仮)
+#define RIGHT_ROTARY_ENCODER    15    // 右ロータリーエンコーダのセンサのピン番号
+#define LEFT_ROTARY_ENCODER     14    // 左ロータリーエンコーダのセンサのピン番号
 
 // ピン番号
 int rightMotorPWMGo     = RIGHT_MOTOR_PWM_GO;
@@ -25,7 +29,8 @@ int frontCenterSensor   = FRONT_CENTER_SENSOR;
 int sideRightSensor     = SIDE_RIGHT_SENSOR;
 int sideLeftSensor      = SIDE_LEFT_SENSOR;
 int magnetSensor        = MAGNET_SENSOR;
-
+int rightRotary_Encoder = RIGHT_ROTARY_ENCODER;
+int leftRotary_Encoder  = LEFT_ROTARY_ENCODER;
 
 WBRControl wbr( 
   rightMotorPWMGo,
@@ -38,7 +43,9 @@ WBRControl wbr(
   frontCenterSensor,
   sideRightSensor,
   sideLeftSensor,
-  magnetSensor
+  magnetSensor,
+  rightRotary_Encoder,
+  leftRotary_Encoder
   );
 
 void setup(){

--- a/WBRControl/Rotary_Encoder.cpp.txt
+++ b/WBRControl/Rotary_Encoder.cpp.txt
@@ -1,0 +1,72 @@
+/**
+ *回転数確認_Rotary_Encoder
+ *左右のタイヤについているロータリーエンコーダのパルスを見て、タイヤが指定された回数回転するまで監視する
+ *いくつ回転してほしいかを回転数で入力してください。ex.半回転→0.5
+ */
+
+
+void WBRControl::Rotary_Encoder(int RightSpinCount_TargetValue, int LeftSpinCount_TargetValue){
+
+
+
+int pinRightRotary_Encoder;			//右モーターのロータリーエンコーダ出力ピン
+int pinLeftRotary_Encoder;			//左モーターのロータリーエンコーダ出力ピン
+int RightSpinCount;					//右ロータリーエンコーダのパルス出力を蓄積
+int LeftSpinCount;					//左ロータリーエンコーダのパルス出力を蓄積
+int RightSpinCount_TargetValue;		//右ロータリーエンコーダ―の目的のパルス数（関数呼び出し時に引数で持ってくる）
+int LeftSpinCount_TargetValue;		//左ロータリーエンコーダ―の目的のパルス数（関数呼び出し時に引数で持ってくる）
+
+
+	Serial.println("Start Rotary_Encoder Check.")
+	
+	RightSpinCount_TargetValue *= ROTARY_ENCODER_COUNT;
+	LeftSpinCount_TargetValue *= ROTARY_ENCODER_COUNT;
+	
+	while((RightSpinCount_TargetValue)>=RightSpinCount && (LeftSpinCount_TargetValue)>=LeftSpinCount){
+	
+		int R_right = digitalRead(pinRightRotary_Encoder);	//S_rightに右ロータリーエンコーダの出力を格納
+		int R_left = digitalRead(pinLeftRotary_Encoder);	//S_leftに左ロータリーエンコーダの出力を格納
+	
+		if(R_right==1){		//右ロータリーエンコーダからパルスが出力されたらカウントを追加
+		RightSpinCount++;
+		}
+	
+		if(R_left==1){		//左ロータリーエンコーダからパルスが出力されたらカウントを追加
+		LeftSpinCount++;
+		}
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	While(ROTARY_ENCODER_COUNT==RightSpinCount){
+	
+	int S_right = digitalRead(pinRightRotary_Encoder);	//右ロータリーエンコーダがパルスを出力しているか確認
+	
+		if(S_right==1){		//パルスが出力されたらカウントを追加
+		RightSpinCount++;
+		}
+	}
+	
+	
+	While(ROTARY_ENCODER_COUNT==LeftSpinCount){
+	
+	int S_left = digitalRead(pinLeftRotary_Encoder);	//左ロータリーエンコーダがパルスを出力しているか確認
+	
+		if(S_left==1){
+		LeftSpinCount++;
+		}
+	}
+}	
+	
+//タイヤの半径は２７ｍｍ

--- a/WBRControl/WBRControl.cpp
+++ b/WBRControl/WBRControl.cpp
@@ -16,8 +16,11 @@ WBRControl::WBRControl(
     int _pinFrontCenterSensor,
     int _pinSideRightSensor,
     int _pinSideLeftSensor,
-    int _pinMagnetSensor){
-
+    int _pinMagnetSensor,
+    int _pinRightRotary_Encoder,
+	int _pinLeftRotary_Encoder
+	){
+		
 		pinRightMotorPWMGo 		= _pinRightMotorPWMGo;
     	pinRightMotorPWMBack 	= _pinRightMotorPWMBack;
     	pinLeftMotorPWMGo 		= _pinLeftMotorPWMGo;
@@ -29,7 +32,8 @@ WBRControl::WBRControl(
     	pinSideRightSensor 		= _pinSideRightSensor;
     	pinSideLeftSensor 		= _pinSideLeftSensor;
     	pinMagnetSensor 		= _pinMagnetSensor;
-	
+		pinRightRotary_Encoder	= _pinRightRotary_Encoder;
+		pinLeftRotary_Encoder	= _pinLeftRotary_Encoder;
 }
 
 /** 
@@ -49,7 +53,9 @@ void WBRControl::pinInit(){
 	pinMode(pinSideRightSensor, INPUT);
 	pinMode(pinSideLeftSensor, INPUT);
 	pinMode(pinMagnetSensor, INPUT);
-		
+	pinMode(pinRightRotary_Encoder, INPUT);
+	pinMode(pinLeftRotary_Encoder, INPUT);
+	
 }
 
 /** 
@@ -398,6 +404,8 @@ void WBRControl::Turn90deg(int *turn){
 			analogWrite(pinRightMotorPWMGo,0);
 			analogWrite(pinRightMotorPWMBack,TURN_PWM);		
 			
+			Rotary_Encoder(1, 1);	//タイヤの回転数を確認
+			
 			delay(SPIN_DELAY_TIME);	
 
 		}
@@ -415,6 +423,8 @@ void WBRControl::Turn90deg(int *turn){
 			
 			analogWrite(pinRightMotorPWMGo,TURN_PWM);
 			analogWrite(pinRightMotorPWMBack,0);
+			
+			Rotary_Encoder(1, 1);	//タイヤの回転数を確認
 			
 			delay(SPIN_DELAY_TIME);	
 
@@ -457,4 +467,35 @@ void WBRControl::BackHome(int *turn){
 
 	}
 	Serial.println("Out BackHome.");
+}
+
+/**
+ *回転数確認_Rotary_Encoder
+ *左右のタイヤについているロータリーエンコーダのパルスを見て、タイヤが指定された回数回転するまで監視する
+ *いくつ回転してほしいかを回転数で入力してください。ex.半回転→0.5
+ */
+void WBRControl::Rotary_Encoder(int RightSpinCount_TargetValue, int LeftSpinCount_TargetValue){
+
+int RightSpinCount = 0;					//右ロータリーエンコーダのパルス出力を蓄積
+int LeftSpinCount = 0;					//左ロータリーエンコーダのパルス出力を蓄積
+	
+	Serial.println("Start Rotary_Encoder Check.");
+	
+	RightSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;
+	LeftSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;		//一回転に必要なパルス数にタイヤの回転数をかけて、必要なパルス数を用意する
+	
+	
+	while(RightSpinCount_TargetValue >= RightSpinCount && LeftSpinCount_TargetValue >= LeftSpinCount){
+	
+		int R_right = digitalRead(pinRightRotary_Encoder);	//R_rightに右ロータリーエンコーダの出力を格納
+		int R_left = digitalRead(pinLeftRotary_Encoder);	//R_leftに左ロータリーエンコーダの出力を格納
+	
+		if(R_right==1){		//右ロータリーエンコーダからパルスが出力されたらカウントを追加
+		RightSpinCount++;
+		}
+	
+		if(R_left==1){		//左ロータリーエンコーダからパルスが出力されたらカウントを追加
+		LeftSpinCount++;
+		}
+	}
 }

--- a/WBRControl/WBRControl.h
+++ b/WBRControl/WBRControl.h
@@ -1,84 +1,93 @@
-#ifndef WBRControl_H_
+﻿#ifndef WBRControl_H_
 #define WBRControl_H_
 
 // WBRMain
-#define BAD_BATTERY         0.5        //	バッテリーが無くなったの電圧
+#define BAD_BATTERY			0.5		//	バッテリーが無くなったの電圧
 
 //　FloorCheck
 // (非常に残念なことに、床があるときにセンサが返す値は０[LOW]です)
-#define FLOOR_EXIST         0          // 床あり
-#define FLOOR_NOTEXIST      1          // 床なし
+#define FLOOR_EXIST			0		// 床あり
+#define FLOOR_NOTEXIST		1		// 床なし
 
 //　CornerCheck
-#define CORNER_EXIST        1          // 角あり
-#define CORNER_NOTEXIST      0          // 角なし
+#define CORNER_EXIST		1		// 角あり
+#define CORNER_NOTEXIST		0		// 角なし
 
 //　FloorDirectionturning
-#define TURN_PWM            145        // モーターの回転数
-#define FLOOR_DELAY_TIME 		100        // 調整時の待機時間
+#define TURN_PWM				145		// モーターの回転数
+#define FLOOR_DELAY_TIME 		100		// 調整時の待機時間
 
 //　GoForward
-#define RIGHT_PWM_SPEED			179         // 前進時右モーターの回転数
-#define LEFT_PWM_SPEED      234         // 前進時左モーターの回転数
+#define RIGHT_PWM_SPEED		179		// 前進時右モーターの回転数
+#define LEFT_PWM_SPEED		234		// 前進時左モーターの回転数
 
 //　StartBatteryCheck
-#define START_BATTERY 			3.5        //十分にバッテリーが充電されているときの電圧
-#define CHARGE_DELAY_TIME   1000	     // 充電待機時間
+#define START_BATTERY			3.5		//十分にバッテリーが充電されているときの電圧
+#define CHARGE_DELAY_TIME		1000		// 充電待機時間
 
 // Turn90deg
-#define SPIN_DELAY_TIME			500        // 回転時の待機時間
-#define NEXT_TURN_RIGHT			0          //回転方向を右回りに
-#define NEXT_TURN_LEFT			1          //回転方向を左回りに
+#define SPIN_DELAY_TIME		500		// 回転時の待機時間
+#define NEXT_TURN_RIGHT		0		//回転方向を右回りに
+#define NEXT_TURN_LEFT		1		//回転方向を左回りに
 
 //　BackHome
-#define MGNET_SERACH_DELAY_TIME 500	  // 磁力感知のための待機時間
+#define MGNET_SERACH_DELAY_TIME		500		// 磁力感知のための待機時間
+
+//　Rotary_Encoder
+#define ROTARY_ENCODER_SPIN		1		//タイヤの回転数を指定
+#define SPINCOUNT_TARGETVALUE		4		//一回転に必要なパルス数
 
 #include "arduino.h"
- 
+
 
 class WBRControl
 {
 	private:
-		int pinRightMotorPWMGo;      // 左モーターのＰＷＭ正接出力ピン(デジタル)
-  	    int pinRightMotorPWMBack;    // 左モーターのＰＷＭ逆接出力ピン(デジタル)
-  	    int pinLeftMotorPWMGo;       // 右モーターのＰＷＭ正接出力ピン(デジタル)
-  	    int pinLeftMotorPWMBack;     // 右モーターのＰＷＭ逆接出力ピン(デジタル)
-  	    int pinReadBattery;          //　電圧測定用ピン(センサ番号仮)
-  	    int pinFrontRightSensor;		 // 前方右センサのピン番号(デジダル)
-  	    int pinFrontLeftSensor;			 // 前方左センサのピン番号（デジタル）
-  	    int pinFrontCenterSensor;		 // 前方中央センサのピン番号（存在しない場合は省く）（デジタル）
-  	    int pinSideRightSensor;			 // 右側面センサのピン番号（デジタル）
-  	    int pinSideLeftSensor;			 // 左側面センサのピン番号（デジタル）
-  	    int pinMagnetSensor;			   // 給電所で磁力を検知するためのセンサのピン番号(そもそもセンサが存在するのだろうか？)(センサ番号仮)
+		int pinRightMotorPWMGo;		// 左モーターのＰＷＭ正接出力ピン(デジタル)
+		int pinRightMotorPWMBack;		// 左モーターのＰＷＭ逆接出力ピン(デジタル)
+		int pinLeftMotorPWMGo;		// 右モーターのＰＷＭ正接出力ピン(デジタル)
+		int pinLeftMotorPWMBack;		// 右モーターのＰＷＭ逆接出力ピン(デジタル)
+		int pinReadBattery;		// 電圧測定用ピン(センサ番号仮)
+		int pinFrontRightSensor;		// 前方右センサのピン番号(デジダル)
+		int pinFrontLeftSensor;		// 前方左センサのピン番号（デジタル）
+		int pinFrontCenterSensor;		// 前方中央センサのピン番号（存在しない場合は省く）（デジタル）
+		int pinSideRightSensor;		// 右側面センサのピン番号（デジタル）
+		int pinSideLeftSensor;		// 左側面センサのピン番号（デジタル）
+		int pinMagnetSensor;		// 給電所で磁力を検知するためのセンサのピン番号(そもそもセンサが存在するのだろうか？)(センサ番号仮)
+		int pinRightRotary_Encoder;		//右モーターのロータリーエンコーダ出力ピン(4月21日現在A3ピン)
+		int pinLeftRotary_Encoder;		//左モーターのロータリーエンコーダ出力ピン(4月21日現在A2ピン)
 
 	public:
-        WBRControl(
-            int pinRightMotorPWMGo,
-            int pinRightMotorPWMBack,
-            int pinLeftMotorPWMGo,
-            int pinLeftMotorPWMBack,
-            int pinReadBattery,
-            int pinFrontRightSensor,
-            int pinFrontLeftSensor,
-            int pinFrontCenterSensor,
-            int pinSideRightSensor,
-            int pinSideLeftSensor,
-            int pinMagnetSensor
-  	);
+		WBRControl(
+		int pinRightMotorPWMGo,
+		int pinRightMotorPWMBack,
+		int pinLeftMotorPWMGo,
+		int pinLeftMotorPWMBack,
+		int pinReadBattery,
+		int pinFrontRightSensor,
+		int pinFrontLeftSensor,
+		int pinFrontCenterSensor,
+		int pinSideRightSensor,
+		int pinSideLeftSensor,
+		int pinMagnetSensor,
+		int pinRightRotary_Encoder,
+		int pinLeftRotary_Encoder
+	);
 
-    int WBRMain();
-    void pinInit();
-    int FloorCheck();
-    int CornerCheck(int *turn);
-    void FloorDirectionTurning();
-    void FloorTurningRight();
-    void FloorTurningLeft();
-    void GoForward();
-    void StartupBatteryCheck();
-    void Turn180deg(int *turn);
-    void Turn90deg(int *turn);
-    void BackHome(int *turn);
-    
+	int WBRMain();
+	void pinInit();
+	int FloorCheck();
+	int CornerCheck(int *turn);
+	void FloorDirectionTurning();
+	void FloorTurningRight();
+	void FloorTurningLeft();
+	void GoForward();
+	void StartupBatteryCheck();
+	void Turn180deg(int *turn);
+	void Turn90deg(int *turn);
+	void BackHome(int *turn);
+	void Rotary_Encoder(int RightSpinCount_TargetValue, int LeftSpinCount_TargetValue);
+
 };
 
 #endif


### PR DESCRIPTION
タイヤを手動で回転させた場合に限り，パルス波の確認が可能となり，正しくプログラムが機能しました．
しかし，タイヤをモーターで回した場合，パルス波が一度に複数回入力されてしまっており，タイヤが一回転する前に関数が終了してしまいます．原因は今のルンバのロータリーエンコーダの凸凹数が少ないというのもあると思います．