### PR TITLE
[WIP]カウント重複防止の修正、引数指定の変更、ほか微修正

### DIFF
--- a/WBRControl.ino
+++ b/WBRControl.ino
@@ -1,7 +1,6 @@
 #include <WBRControl.h>
 
 
-
 // ピン番号アサイン(0はセンサーを使用しないことを指定）
 #define LEFT_MOTOR_PWM_GO       11    // 左モーターのＰＷＭ正接出力ピン(デジタル)
 #define LEFT_MOTOR_PWM_BACK     10    // 左モーターのＰＷＭ逆接出力ピン(デジタル)

--- a/WBRControl/WBRControl.cpp
+++ b/WBRControl/WBRControl.cpp
@@ -349,14 +349,14 @@ void WBRControl::Turn180deg(int *turn){
 		analogWrite(pinLeftMotorPWMGo,LEFT_PWM_SPEED);		//車体分前進
 		analogWrite(pinLeftMotorPWMBack,0);					
 	
-		analogWrite(pinRightMotorPWMGo, RIGHT_PWM_SPEED);	。
-		analogWrite(pinRightMotorPWMBack, 0);	
+		analogWrite(pinRightMotorPWMGo, RIGHT_PWM_SPEED);
+		analogWrite(pinRightMotorPWMBack, 0);
 		Rotary_Encoder(1, 1);
 
 		analogWrite(pinLeftMotorPWMGo, 0);
 		analogWrite(pinRightMotorPWMGo, 0);
 	
-	}
+	
 
 	Turn90deg(turn);	// 90度回転
 		

--- a/WBRControl/WBRControl.cpp
+++ b/WBRControl/WBRControl.cpp
@@ -257,7 +257,8 @@ void WBRControl::FloorDirectionTurning(){
 
 	// モーターの停止
 	analogWrite(pinLeftMotorPWMGo,0);
-	analogWrite(pinLeftMotorPWMBack,0);		
+	analogWrite(pinLeftMotorPWMBack,0);	
+
 	analogWrite(pinRightMotorPWMGo,0);
 	analogWrite(pinRightMotorPWMBack,0);
 
@@ -274,8 +275,9 @@ void WBRControl::FloorTurningRight(){
 
 	analogWrite(pinLeftMotorPWMGo,TURN_PWM);
 	analogWrite(pinLeftMotorPWMBack,0);			//　PWM値は仮
+
 	analogWrite(pinRightMotorPWMGo,0);
-	analogWrite(pinRightMotorPWMBack,TURN_PWM);
+	analogWrite(pinRightMotorPWMBack,0);
 
 	Serial.println("Out FloorTurningRight.");
 		
@@ -290,7 +292,8 @@ void WBRControl::FloorTurningLeft(){
 	Serial.println("In FloorTurningLeft.");
 
 	analogWrite(pinLeftMotorPWMGo,0);
-	analogWrite(pinLeftMotorPWMBack,TURN_PWM);		
+	analogWrite(pinLeftMotorPWMBack,0);	
+
 	analogWrite(pinRightMotorPWMGo,TURN_PWM);
 	analogWrite(pinRightMotorPWMBack,0);
 	
@@ -351,6 +354,7 @@ void WBRControl::Turn180deg(int *turn){
 	
 		analogWrite(pinRightMotorPWMGo, RIGHT_PWM_SPEED);
 		analogWrite(pinRightMotorPWMBack, 0);
+		
 		Rotary_Encoder(1, 1);
 
 		analogWrite(pinLeftMotorPWMGo, 0);
@@ -393,7 +397,7 @@ void WBRControl::Turn90deg(int *turn){
 			analogWrite(pinRightMotorPWMGo,0);
 			analogWrite(pinRightMotorPWMBack,TURN_PWM);		
 			
-			Rotary_Encoder(1, 1);	//タイヤの回転数を確認			
+			Rotary_Encoder(0.25, 0.25);	//タイヤの回転数を確認			
 	}
 
 	// 左折
@@ -405,7 +409,7 @@ void WBRControl::Turn90deg(int *turn){
 			analogWrite(pinRightMotorPWMGo,TURN_PWM);
 			analogWrite(pinRightMotorPWMBack,0);
 
-			Rotary_Encoder(1, 1);	//タイヤの回転数を確認
+			Rotary_Encoder(0.25, 0.25);	//タイヤの回転数を確認
 			
 	}
 	Serial.println("Out Turn90deg.");
@@ -450,29 +454,48 @@ void WBRControl::BackHome(int *turn){
  *回転数確認_Rotary_Encoder
  *左右のタイヤについているロータリーエンコーダのパルスを見て、タイヤが指定された回数回転するまで監視する
  *いくつ回転してほしいかを回転数で入力してください。ex.半回転→0.5
+ *車輪のサイズは17/6/16時点では56mm,車体の円の直径は180mmです.
  */
-void WBRControl::Rotary_Encoder(int RightSpinCount_TargetValue, int LeftSpinCount_TargetValue){
+void WBRControl::Rotary_Encoder(int LeftSpinCount_TargetValue, int RightSpinCount_TargetValue){
 
-int RightSpinCount = 0;					//右ロータリーエンコーダのパルス出力を蓄積
-int LeftSpinCount = 0;					//左ロータリーエンコーダのパルス出力を蓄積
+	int RightSpinCount = 0;					//右ロータリーエンコーダのパルス出力を蓄積
+	int LeftSpinCount = 0;					//左ロータリーエンコーダのパルス出力を蓄積
+
 	
 	Serial.println("Start Rotary_Encoder Check.");
+	
+
 	
 	RightSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;
 	LeftSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;		//一回転に必要なパルス数にタイヤの回転数をかけて、必要なパルス数を用意する
 	
-	
+	int beforeR_right = 1;
+	int beforeR_left = 1;
+
+
 	while(RightSpinCount_TargetValue >= RightSpinCount && LeftSpinCount_TargetValue >= LeftSpinCount){
 	
 		int R_right = digitalRead(pinRightRotary_Encoder);	//R_rightに右ロータリーエンコーダの出力を格納
 		int R_left = digitalRead(pinLeftRotary_Encoder);	//R_leftに左ロータリーエンコーダの出力を格納
 	
 		if(R_right==1){		//右ロータリーエンコーダからパルスが出力されたらカウントを追加
-		RightSpinCount++;
+			if(beforeR_right == 0){
+				RightSpinCount++;
+			}
 		}
 	
 		if(R_left==1){		//左ロータリーエンコーダからパルスが出力されたらカウントを追加
-		LeftSpinCount++;
+			if(beforeR_right == 0){
+				LeftSpinCount++;
+			}
 		}
+
+		beforeR_right = R_right;
+		beforeR_left = R_left;
+
 	}
+
+	Serial.println("End Rotary_Encoder Check.");
+	
+	
 }

--- a/WBRControl/WBRControl.cpp
+++ b/WBRControl/WBRControl.cpp
@@ -461,18 +461,32 @@ int LeftSpinCount = 0;					//左ロータリーエンコーダのパルス出力
 	RightSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;
 	LeftSpinCount_TargetValue *= SPINCOUNT_TARGETVALUE;		//一回転に必要なパルス数にタイヤの回転数をかけて、必要なパルス数を用意する
 	
-	
+	int beforeR_right = 1;
+	int beforeR_left = 1;
+
+
 	while(RightSpinCount_TargetValue >= RightSpinCount && LeftSpinCount_TargetValue >= LeftSpinCount){
 	
 		int R_right = digitalRead(pinRightRotary_Encoder);	//R_rightに右ロータリーエンコーダの出力を格納
 		int R_left = digitalRead(pinLeftRotary_Encoder);	//R_leftに左ロータリーエンコーダの出力を格納
 	
 		if(R_right==1){		//右ロータリーエンコーダからパルスが出力されたらカウントを追加
-		RightSpinCount++;
+			if(beforeR_right == 1){
+				RightSpinCount++;
+			}
 		}
 	
 		if(R_left==1){		//左ロータリーエンコーダからパルスが出力されたらカウントを追加
-		LeftSpinCount++;
+			if(beforeR_right == 1){
+				LeftSpinCount++;
+			}
 		}
+
+		beforeR_right = R_right;
+		beforeR_left = R_left;
+
 	}
+
+	Serial.println("End Rotary_Encoder Check.");
+	
 }

--- a/WBRControl/WBRControl.cpp
+++ b/WBRControl/WBRControl.cpp
@@ -346,24 +346,16 @@ void WBRControl::Turn180deg(int *turn){
 
 	Turn90deg(turn);								// 90度回転
 
-	//　前進、iの値は仮
-	for(int i=1;i<=5;i++){
-			
+		analogWrite(pinLeftMotorPWMGo,LEFT_PWM_SPEED);		//車体分前進
+		analogWrite(pinLeftMotorPWMBack,0);					
+	
+		analogWrite(pinRightMotorPWMGo, RIGHT_PWM_SPEED);	。
+		analogWrite(pinRightMotorPWMBack, 0);	
+		Rotary_Encoder(1, 1);
+
 		analogWrite(pinLeftMotorPWMGo, 0);
-		analogWrite(pinLeftMotorPWMBack, 0);
-		
-		analogWrite(pinRightMotorPWMGo, TURN_PWM);
-		analogWrite(pinRightMotorPWMBack, 0);
-		
-		delay(SPIN_DELAY_TIME);
-
-		//　飛び出してないか判定、飛び出していた場合前進をやめる
-		if(digitalRead(pinFrontRightSensor) == 0 || digitalRead(pinFrontLeftSensor) == 0){
-
-			break;
-
-		}
-
+		analogWrite(pinRightMotorPWMGo, 0);
+	
 	}
 
 	Turn90deg(turn);	// 90度回転
@@ -394,9 +386,6 @@ void WBRControl::Turn90deg(int *turn){
 
 	//右折
 	if (*turn == 0) {
-
-		// iの値は仮
-		for(int i = 1; i <= 5; i++){
 				
 			analogWrite(pinLeftMotorPWMGo,TURN_PWM);	
 			analogWrite(pinLeftMotorPWMBack,0);	//PWM値は仮	
@@ -404,32 +393,20 @@ void WBRControl::Turn90deg(int *turn){
 			analogWrite(pinRightMotorPWMGo,0);
 			analogWrite(pinRightMotorPWMBack,TURN_PWM);		
 			
-			Rotary_Encoder(1, 1);	//タイヤの回転数を確認
-			
-			delay(SPIN_DELAY_TIME);	
-
-		}
-
+			Rotary_Encoder(1, 1);	//タイヤの回転数を確認			
 	}
 
 	// 左折
 	else {
 
-		//iの値は仮
-		for(int i = 1; i <= 5; i++){
-				
 			analogWrite(pinLeftMotorPWMGo,0);
 			analogWrite(pinLeftMotorPWMBack,TURN_PWM);	
 			
 			analogWrite(pinRightMotorPWMGo,TURN_PWM);
 			analogWrite(pinRightMotorPWMBack,0);
-			
+
 			Rotary_Encoder(1, 1);	//タイヤの回転数を確認
 			
-			delay(SPIN_DELAY_TIME);	
-
-		}
-
 	}
 	Serial.println("Out Turn90deg.");
 }

--- a/WBRControl/WBRControl.h
+++ b/WBRControl/WBRControl.h
@@ -14,12 +14,12 @@
 #define CORNER_NOTEXIST		0		// 角なし
 
 //　FloorDirectionturning
-#define TURN_PWM				145		// モーターの回転数
-#define FLOOR_DELAY_TIME 		100		// 調整時の待機時間
+#define TURN_PWM				100		// モーターの回転数
+#define FLOOR_DELAY_TIME 		1		// 調整時の待機時間
 
 //　GoForward
-#define RIGHT_PWM_SPEED		179		// 前進時右モーターの回転数
-#define LEFT_PWM_SPEED		234		// 前進時左モーターの回転数
+#define RIGHT_PWM_SPEED		169		// 前進時右モーターの回転数
+#define LEFT_PWM_SPEED		184		// 前進時左モーターの回転数
 
 //　StartBatteryCheck
 #define START_BATTERY			3.5		//十分にバッテリーが充電されているときの電圧

--- a/WBRControl/WBRControl.h
+++ b/WBRControl/WBRControl.h
@@ -14,12 +14,12 @@
 #define CORNER_NOTEXIST		0		// 角なし
 
 //　FloorDirectionturning
-#define TURN_PWM				100		// モーターの回転数
+#define TURN_PWM				134		// モーターの回転数
 #define FLOOR_DELAY_TIME 		1		// 調整時の待機時間
 
 //　GoForward
-#define RIGHT_PWM_SPEED		169		// 前進時右モーターの回転数
-#define LEFT_PWM_SPEED		184		// 前進時左モーターの回転数
+#define RIGHT_PWM_SPEED		189		// 前進時右モーターの回転数
+#define LEFT_PWM_SPEED		204		// 前進時左モーターの回転数
 
 //　StartBatteryCheck
 #define START_BATTERY			3.5		//十分にバッテリーが充電されているときの電圧
@@ -34,8 +34,8 @@
 #define MGNET_SERACH_DELAY_TIME		500		// 磁力感知のための待機時間
 
 //　Rotary_Encoder
-#define ROTARY_ENCODER_SPIN		1		//タイヤの回転数を指定
-#define SPINCOUNT_TARGETVALUE		4		//一回転に必要なパルス数
+#define SPINCOUNT_TARGETVALUE		14		//一回転に必要なパルス数（2世代目の値、1世代目は4）
+
 
 #include "arduino.h"
 


### PR DESCRIPTION
　単純にロータリーエンコーダーの出力を監視しているだけでは、エンコーダの刃が通っている間にずっとパルスカウントをしてしまっていたため、
出力パルスの変化点だけを見るようにWhileループ内に前ループのセンサの状態を格納させるようにしました。

　それとエンコーダ呼び出し時に「タイヤ」の回転数を指定する際、タイヤ1回転あたりのパルス数を引数で乗算して目的のパルス値へ調整しようとしていましたが、
引数の型がintだったため（float型はマイコンでは好ましくない）1回転のパルス値を引数で除算して算出する方式を取りました。
　これだと1回転以上の指定ができませんが、それ以上させたいときはもう1回関数を呼び出せば良いかなと思ってます。他に良い方法あれば修正願います。

　また、これより前の西口のコミットにて、エンコーダー作成前に仮置きしていたfor文（主にTun90deg）を削除して今回作成した関数へと置き換えを行いました。
　微妙なアプデですがTurn180degにおいても、その場で回転する前にボードのフチに車体がぶつからないようにするため、後方へと少し下がる制御を挟んでおきました。
　関数作成中に機体が変わったため、タイヤ1回転あたりのパルス数も4から14に変更されています。